### PR TITLE
angular-gravatar seems to have moved the md5 dependency

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -33,7 +33,7 @@
 <script src="components/angular-touch/angular-touch.js"></script>
 <script src="components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
 
-<script src="components/angular-gravatar/src/md5.js"></script>
+<script src="components/angular-gravatar/build/md5.js"></script>
 <script src="components/angular-gravatar/build/angular-gravatar.js"></script>
 
 <script src="/_api/_files/hoodie.js"></script>


### PR DESCRIPTION
Previously it was in the src folder and now in build.  If pulling the repo fresh and running "bower install" the project fails to load in the browser because it can't find md5 in the src folder.
